### PR TITLE
Return Support for FT6336 touch controller on Kasperaitis ES3C28P (myoptions)

### DIFF
--- a/builds/kasperaitis/myoptions.h
+++ b/builds/kasperaitis/myoptions.h
@@ -99,6 +99,18 @@
 #endif
 
 
+/* --- TOUCH --- */
+
+#if defined(ESP32_S3_KASPERAITIS_ES3C28P)
+  // For some ES3C28P boards the touch controller may be D-FT6336G family — set to TS_MODEL_FT6336 if required
+  #define TS_MODEL            TS_MODEL_FT6336
+  #define TS_SDA              16
+  #define TS_SCL              15
+  #define TS_INT              17
+  #define TS_RST              18
+#endif
+
+
 /* --- BUTTONS --- */
 
 #if defined(ESP32_S3_KASPERAITIS_ES3C28P)


### PR DESCRIPTION
### Summary
Adds board-specific FT6336 touchscreen config to `myoptions.h` for
Kasperaitis ES3C28P (TS_SDA=16, TS_SCL=15, TS_INT=17, TS_RST=18).

### Why
Many ES3C28P boards use the D‑FT6336G touch controller. Providing
recommended defaults makes it simple to enable touch for that board.

### What changed
- `myoptions.h` — added `/* --- TOUCH --- */` block with FT6336 settings.

### Testing
- Local build: `platformio run --environment esp32_s3_kasperaitis_es3c28p` — ✔️
- Request reviewer to flash to hardware and verify touch responsiveness and report logs/screenshots.

### Backward compatibility
- No global default change; safe to merge. Only affects systems that enable
  `ESP32_S3_KASPERAITIS_ES3C28P` or set `TS_MODEL = TS_MODEL_FT6336`.

### Suggested reviewers
- @trip5, @kasperaitis (or project maintainers)

### Labels
`enhancement`, `board-support`, `documentation`